### PR TITLE
docs: Add LigerKernel performance tuning documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,12 @@ veRL is fast with:
 
 .. toctree::
    :maxdepth: 1
+   :caption: Performance Tuning
+
+   perf/perf_tuning
+
+.. toctree::
+   :maxdepth: 1
    :caption: FAQ
 
    faq/faq

--- a/docs/perf/perf_tuning.rst
+++ b/docs/perf/perf_tuning.rst
@@ -1,0 +1,20 @@
+Performance Tuning
+=================
+
+This guide provides tips and configurations for optimizing the performance of VERL.
+
+LigerKernel for SFT
+------------------
+
+LigerKernel is a high-performance kernel for Supervised Fine-Tuning (SFT) that can improve training efficiency. To enable LigerKernel in your SFT training:
+
+1. In your SFT configuration file (e.g., ``verl/trainer/config/sft_trainer.yaml``), set the ``use_liger`` parameter:
+
+   .. code-block:: yaml
+
+      model:
+        use_liger: True  # Enable LigerKernel for SFT
+
+2. The default value is ``False``. Enable it only when you want to use LigerKernel's optimizations.
+
+3. LigerKernel is particularly useful for improving training performance in SFT scenarios.


### PR DESCRIPTION
This PR adds documentation for the LigerKernel option in a new performance tuning section, addressing the comment from volcengine/verl#173.

Changes:
- Created new performance tuning section in docs
- Documented LigerKernel option for SFT
- Added performance tuning section to documentation index

Related to volcengine/verl#173